### PR TITLE
Fix 1.21.1 NeoForge mixins for renamed height accessors

### DIFF
--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/HeightmapMixin.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/HeightmapMixin.java
@@ -14,8 +14,9 @@ public abstract class HeightmapMixin {
     private static int theexpanse$extendHeightmapTop(ChunkAccess chunkAccess) {
         int vanillaTop = chunkAccess.getHighestSectionPosition();
         int customTop = WorldgenConstants.OVERWORLD_MAX_Y + 1;
-        int minY = chunkAccess.getMinY();
-        int height = chunkAccess.getMaxY() - minY;
+        LevelHeightAccessorExtension accessor = (LevelHeightAccessorExtension) chunkAccess;
+        int minY = accessor.getMinY();
+        int height = accessor.getMaxY() - minY;
         if (height == WorldgenConstants.OVERWORLD_HEIGHT && minY == WorldgenConstants.OVERWORLD_MIN_Y) {
             return Math.max(vanillaTop, customTop);
         }
@@ -25,8 +26,9 @@ public abstract class HeightmapMixin {
     // CUSTOM: extended vertical range (heightmap)
     @Redirect(method = "primeHeightmaps", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/chunk/ChunkAccess;getMinY()I"))
     private static int theexpanse$extendHeightmapBottomPrime(ChunkAccess chunkAccess) {
-        int vanillaMin = chunkAccess.getMinY();
-        int height = chunkAccess.getMaxY() - vanillaMin;
+        LevelHeightAccessorExtension accessor = (LevelHeightAccessorExtension) chunkAccess;
+        int vanillaMin = accessor.getMinY();
+        int height = accessor.getMaxY() - vanillaMin;
         if (height == WorldgenConstants.OVERWORLD_HEIGHT && vanillaMin > WorldgenConstants.OVERWORLD_MIN_Y) {
             return WorldgenConstants.OVERWORLD_MIN_Y;
         }
@@ -36,8 +38,9 @@ public abstract class HeightmapMixin {
     // CUSTOM: extended vertical range (heightmap)
     @Redirect(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/chunk/ChunkAccess;getMinY()I"))
     private int theexpanse$extendHeightmapBottomUpdate(ChunkAccess chunkAccess) {
-        int vanillaMin = chunkAccess.getMinY();
-        int height = chunkAccess.getMaxY() - vanillaMin;
+        LevelHeightAccessorExtension accessor = (LevelHeightAccessorExtension) chunkAccess;
+        int vanillaMin = accessor.getMinY();
+        int height = accessor.getMaxY() - vanillaMin;
         if (height == WorldgenConstants.OVERWORLD_HEIGHT && vanillaMin > WorldgenConstants.OVERWORLD_MIN_Y) {
             return WorldgenConstants.OVERWORLD_MIN_Y;
         }

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/LevelHeightAccessorExtension.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/LevelHeightAccessorExtension.java
@@ -1,0 +1,12 @@
+package com.cyberday1.theexpanse.mixin;
+
+/**
+ * Bridge interface that exposes the NeoForge 1.21.1 height accessors while compiling against
+ * the existing LevelHeightAccessor type. Implemented via mixin to keep call sites using the
+ * new {@code getMinY}/{@code getMaxY} contract without introducing reflection.
+ */
+public interface LevelHeightAccessorExtension {
+    int getMinY();
+
+    int getMaxY();
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/LevelHeightAccessorMixin.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/LevelHeightAccessorMixin.java
@@ -5,9 +5,26 @@ import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.LevelHeightAccessor;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(LevelHeightAccessor.class)
-public interface LevelHeightAccessorMixin {
+public interface LevelHeightAccessorMixin extends LevelHeightAccessorExtension {
+    @Shadow
+    int getMinBuildHeight();
+
+    @Shadow
+    int getMaxBuildHeight();
+
+    @Override
+    default int getMinY() {
+        return this.getMinBuildHeight();
+    }
+
+    @Override
+    default int getMaxY() {
+        return this.getMaxBuildHeight();
+    }
+
     // CUSTOM: extended vertical range (sectionpos)
     @Overwrite
     default int getMinSection() {


### PR DESCRIPTION
## Summary
- extend the LevelHeightAccessor mixin with bridge methods that expose getMinY/getMaxY while delegating to the existing build height accessors
- update the heightmap mixin to rely on the new bridge so chunk-based redirects can read the NeoForge 1.21.1 bounds API

## Testing
- ./gradlew --console=plain :1.21.1-neoforge:compileJava

------
https://chatgpt.com/codex/tasks/task_e_68daec1b08e88327960af6a9546b5eb9