### PR TITLE
Refine NeoForge 1.21.1 height bridge helpers

### DIFF
--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/HeightmapMixin.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/HeightmapMixin.java
@@ -16,8 +16,7 @@ public abstract class HeightmapMixin {
         int customTop = WorldgenConstants.OVERWORLD_MAX_Y + 1;
         LevelHeightAccessorExtension accessor = (LevelHeightAccessorExtension) chunkAccess;
         int minY = accessor.getMinY();
-        int height = accessor.getMaxY() - minY;
-        if (height == WorldgenConstants.OVERWORLD_HEIGHT && minY == WorldgenConstants.OVERWORLD_MIN_Y) {
+        if (theexpanse$shouldExtendTop(accessor, minY)) {
             return Math.max(vanillaTop, customTop);
         }
         return vanillaTop;
@@ -28,8 +27,7 @@ public abstract class HeightmapMixin {
     private static int theexpanse$extendHeightmapBottomPrime(ChunkAccess chunkAccess) {
         LevelHeightAccessorExtension accessor = (LevelHeightAccessorExtension) chunkAccess;
         int vanillaMin = accessor.getMinY();
-        int height = accessor.getMaxY() - vanillaMin;
-        if (height == WorldgenConstants.OVERWORLD_HEIGHT && vanillaMin > WorldgenConstants.OVERWORLD_MIN_Y) {
+        if (theexpanse$shouldExtendBottom(accessor, vanillaMin)) {
             return WorldgenConstants.OVERWORLD_MIN_Y;
         }
         return vanillaMin;
@@ -40,10 +38,21 @@ public abstract class HeightmapMixin {
     private int theexpanse$extendHeightmapBottomUpdate(ChunkAccess chunkAccess) {
         LevelHeightAccessorExtension accessor = (LevelHeightAccessorExtension) chunkAccess;
         int vanillaMin = accessor.getMinY();
-        int height = accessor.getMaxY() - vanillaMin;
-        if (height == WorldgenConstants.OVERWORLD_HEIGHT && vanillaMin > WorldgenConstants.OVERWORLD_MIN_Y) {
+        if (theexpanse$shouldExtendBottom(accessor, vanillaMin)) {
             return WorldgenConstants.OVERWORLD_MIN_Y;
         }
         return vanillaMin;
+    }
+
+    private static boolean theexpanse$shouldExtendTop(LevelHeightAccessorExtension accessor, int minY) {
+        return theexpanse$hasFullOverworldSpan(accessor, minY) && minY == WorldgenConstants.OVERWORLD_MIN_Y;
+    }
+
+    private static boolean theexpanse$shouldExtendBottom(LevelHeightAccessorExtension accessor, int minY) {
+        return theexpanse$hasFullOverworldSpan(accessor, minY) && minY > WorldgenConstants.OVERWORLD_MIN_Y;
+    }
+
+    private static boolean theexpanse$hasFullOverworldSpan(LevelHeightAccessorExtension accessor, int minY) {
+        return accessor.getMaxY() - minY == WorldgenConstants.OVERWORLD_HEIGHT;
     }
 }

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/LevelHeightAccessorMixin.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/LevelHeightAccessorMixin.java
@@ -30,7 +30,7 @@ public interface LevelHeightAccessorMixin extends LevelHeightAccessorExtension {
     default int getMinSection() {
         int minY = this.getMinY();
         int height = this.getMaxY() - minY;
-        if (minY == WorldgenConstants.OVERWORLD_MIN_Y && height == WorldgenConstants.OVERWORLD_HEIGHT) {
+        if (theexpanse$usesCustomOverworldBounds(minY, height)) {
             return SectionPos.blockToSectionCoord(WorldgenConstants.OVERWORLD_MIN_Y);
         }
         return SectionPos.blockToSectionCoord(minY);
@@ -41,7 +41,7 @@ public interface LevelHeightAccessorMixin extends LevelHeightAccessorExtension {
     default int getMaxSection() {
         int minY = this.getMinY();
         int height = this.getMaxY() - minY;
-        if (minY == WorldgenConstants.OVERWORLD_MIN_Y && height == WorldgenConstants.OVERWORLD_HEIGHT) {
+        if (theexpanse$usesCustomOverworldBounds(minY, height)) {
             return SectionPos.blockToSectionCoord(WorldgenConstants.OVERWORLD_MAX_Y) + 1;
         }
         return SectionPos.blockToSectionCoord(this.getMaxY() - 1) + 1;
@@ -52,9 +52,13 @@ public interface LevelHeightAccessorMixin extends LevelHeightAccessorExtension {
     default int getSectionsCount() {
         int minY = this.getMinY();
         int height = this.getMaxY() - minY;
-        if (minY == WorldgenConstants.OVERWORLD_MIN_Y && height == WorldgenConstants.OVERWORLD_HEIGHT) {
+        if (theexpanse$usesCustomOverworldBounds(minY, height)) {
             return WorldgenConstants.OVERWORLD_SECTION_COUNT;
         }
         return this.getMaxSection() - this.getMinSection();
+    }
+
+    private static boolean theexpanse$usesCustomOverworldBounds(int minY, int height) {
+        return minY == WorldgenConstants.OVERWORLD_MIN_Y && height == WorldgenConstants.OVERWORLD_HEIGHT;
     }
 }


### PR DESCRIPTION
## Summary
- factor the overworld height checks in LevelHeightAccessorMixin through a shared helper to keep the bridge logic consistent
- add shared helpers in HeightmapMixin so top and bottom adjustments consistently rely on the new getMinY/getMaxY bridge

## Testing
- `./gradlew :1.21.1-neoforge:compileJava --console=plain --no-daemon` *(fails: Gradle is blocked by a stale fabric-loom cache lock owned by defunct process 3928)*

------
https://chatgpt.com/codex/tasks/task_e_68daf1a014348327b4c17ebaf5133d40