### PR TITLE
Specify NeoForm dependency for 1.21.1 NeoForge build

### DIFF
--- a/versions/1.21.1-neoforge/gradle.properties
+++ b/versions/1.21.1-neoforge/gradle.properties
@@ -2,6 +2,7 @@ modstitch.platform=moddevgradle
 
 deps.minecraft=1.21.1
 deps.neoforge=21.1.209
+deps.neoform=1.21.1-20240808.144430
 deps.lithostitched=1.4.5-neoforge-1.21
 deps.terralith=MuJMtPGQ
 deps.clifftree=2.0.1+mod


### PR DESCRIPTION
## Summary
- add the published NeoForm version to the 1.21.1 NeoForge configuration so the runtime is re-downloaded with fresh cache contents

## Testing
- `./gradlew :1.21.1-neoforge:createMinecraftArtifacts --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68db09b8b31c83278f4f812576677d23