### PR TITLE
Pin NeoForm versions and cache artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 A modified version of The Expanse 3.0, increased build and generation height
+
+## NeoForm troubleshooting
+
+If NeoForm's `createMinecraftArtifacts` task fails or appears to rerun unnecessarily:
+
+1. Stop Gradle daemons with `./gradlew --stop`.
+2. Remove only the NeoForm caches:
+   - `%USERPROFILE%\.gradle\caches\neoform`
+   - `%USERPROFILE%\.gradle\caches\neoforge`
+3. Re-run the desired Gradle task.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,10 @@ dependencies {
     //modstitchModImplementation("maven.modrinth:clifftree:${property("deps.clifftree")}")
 }
 
+tasks.named("createMinecraftArtifacts") {
+    outputs.cacheIf { true }
+}
+
 tasks {
     modstitch.finalJarTask {
         archiveVersion.set("$modVersion-$loader-$minecraft")

--- a/versions/1.21.1-neoforge/build.gradle.kts
+++ b/versions/1.21.1-neoforge/build.gradle.kts
@@ -1,0 +1,4 @@
+neoForge {
+    version = "21.1.39-beta"
+    neoFormVersion = "1.21.1-20240808.144430"
+}

--- a/versions/1.21.5-neoforge/build.gradle.kts
+++ b/versions/1.21.5-neoforge/build.gradle.kts
@@ -1,0 +1,4 @@
+neoForge {
+    version = "21.5.39-beta"
+    neoFormVersion = "1.21.5-20240808.144430"
+}


### PR DESCRIPTION
## Summary
- pin NeoForge and NeoForm versions for the 1.21.1 and 1.21.5 modules to stabilize the toolchain
- enable caching for the createMinecraftArtifacts task so Gradle can reuse generated artifacts
- document troubleshooting steps for clearing NeoForm caches when a rebuild is required

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db2082b8008327936516f5dc922a39