### PR TITLE
Align NeoForge module versions with mod_version property

### DIFF
--- a/versions/1.21.1-neoforge/build.gradle.kts
+++ b/versions/1.21.1-neoforge/build.gradle.kts
@@ -1,9 +1,10 @@
 import org.gradle.jvm.tasks.Jar
 
+val modVersion = rootProject.property("mod_version") as String
 val mcVersion = property("deps.minecraft") as String
 
 group = "com.cyberday1"
-version = "2.0.0+mc${mcVersion}-neoforge"
+version = "${modVersion}+mc${mcVersion}-neoforge"
 
 neoForge {
     version = "21.1.39-beta"
@@ -12,6 +13,7 @@ neoForge {
 
 tasks.named<Jar>("jar") {
     archiveBaseName.set("TectonicExpanded")
+    archiveVersion.set("${modVersion}+mc${mcVersion}-neoforge")
 }
 
 tasks.register("sanityCompile") {

--- a/versions/1.21.5-neoforge/build.gradle.kts
+++ b/versions/1.21.5-neoforge/build.gradle.kts
@@ -1,9 +1,10 @@
 import org.gradle.jvm.tasks.Jar
 
+val modVersion = rootProject.property("mod_version") as String
 val mcVersion = property("deps.minecraft") as String
 
 group = "com.cyberday1"
-version = "2.0.0+mc${mcVersion}-neoforge"
+version = "${modVersion}+mc${mcVersion}-neoforge"
 
 neoForge {
     version = "21.5.39-beta"
@@ -12,6 +13,7 @@ neoForge {
 
 tasks.named<Jar>("jar") {
     archiveBaseName.set("TectonicExpanded")
+    archiveVersion.set("${modVersion}+mc${mcVersion}-neoforge")
 }
 
 tasks.register("sanityCompile") {


### PR DESCRIPTION
## Summary
- read the NeoForge module version from the shared `mod_version` property to keep logical and packaged versions aligned
- ensure the produced jar archives retain the `+mc…-neoforge` classifier by explicitly setting the archive version during packaging

## Testing
- ./gradlew clean build --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68db3bd06fc88327b229b14c271b546f