### PR TITLE
Fix NeoForge mod version metadata expansion

### DIFF
--- a/versions/1.21.1-neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/versions/1.21.1-neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,26 +4,26 @@ issueTrackerURL = "https://github.com/CyberDay1/TheExpanse/issues"
 license = "MIT"
 
 [[mods]]
-    modId = "theexpanse"
-    version = "${mod_version}"
-    displayName = "The Expanse"
-    description = "Terrain shaping brought to new heights, grander and more varied than ever before. Welcome to The Expanse."
-    authors = "Apollo (Developer), HB Stratos (Contributor), DawnKiro (Contributor), Uni (Contributor)"
-    logoFile = "pack.png"
+    modId="tectonicexpanded"
+    version="${mod_version}"
+    displayName="Tectonic Expanded"
+    description="Expanded tectonic worldgen"
+    authors="CyberDay1"
+    logoFile="pack.png"
 
-[[dependencies.theexpanse]]
+[[dependencies.tectonicexpanded]]
     modId = "neoforge"
     type = "required"
     versionRange = "[21.1.0,)"
     ordering = "NONE"
     side = "BOTH"
 
-[[dependencies.theexpanse]]
+[[dependencies.tectonicexpanded]]
     modId = "minecraft"
     type = "required"
     versionRange = "[1.21.1,1.21.2)"
 
-[[dependencies.theexpanse]]
+[[dependencies.tectonicexpanded]]
     modId = "lithostitched"
     type = "required"
     ordering = "NONE"

--- a/versions/1.21.5-neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/versions/1.21.5-neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,26 +4,26 @@ issueTrackerURL = "https://github.com/CyberDay1/TheExpanse/issues"
 license = "MIT"
 
 [[mods]]
-    modId = "theexpanse"
-    version = "${mod_version}"
-    displayName = "The Expanse"
-    description = "Terrain shaping brought to new heights, grander and more varied than ever before. Welcome to The Expanse."
-    authors = "Apollo (Developer), HB Stratos (Contributor), DawnKiro (Contributor), Uni (Contributor)"
-    logoFile = "pack.png"
+    modId="tectonicexpanded"
+    version="${mod_version}"
+    displayName="Tectonic Expanded"
+    description="Expanded tectonic worldgen"
+    authors="CyberDay1"
+    logoFile="pack.png"
 
-[[dependencies.theexpanse]]
+[[dependencies.tectonicexpanded]]
     modId = "neoforge"
     type = "required"
     versionRange = "[21.5.0,)"
     ordering = "NONE"
     side = "BOTH"
 
-[[dependencies.theexpanse]]
+[[dependencies.tectonicexpanded]]
     modId = "minecraft"
     type = "required"
     versionRange = "[1.21.5,1.21.6)"
 
-[[dependencies.theexpanse]]
+[[dependencies.tectonicexpanded]]
     modId = "lithostitched"
     type = "required"
     ordering = "NONE"


### PR DESCRIPTION
## Summary
- read the clean mod version from gradle.properties while keeping the project artifact classifier
- restrict resource processing expansion to the NeoForge descriptor and validate both versioned manifests
- update each NeoForge mods.toml descriptor to use the tectonicexpanded metadata block

## Testing
- ./gradlew clean build --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68db4704ef848327b8bfb9318aa44994