### PR TITLE
Remove invalid ChunkSerializer mixin from NeoForge config

### DIFF
--- a/versions/1.21.1-neoforge/src/main/resources/theexpanse_1.21.1.mixins.json
+++ b/versions/1.21.1-neoforge/src/main/resources/theexpanse_1.21.1.mixins.json
@@ -7,7 +7,6 @@
   },
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "ChunkSerializerMixin",
     "com.cyberday1.theexpanse.mixin.HeightmapMixin",
     "com.cyberday1.theexpanse.mixin.LevelHeightAccessorMixin",
     "com.cyberday1.theexpanse.mixin.StrongholdStructureMixin",


### PR DESCRIPTION
## Summary
- remove the ChunkSerializerMixin entry from the 1.21.1 NeoForge mixin configuration to prevent referencing a missing mixin

## Testing
- ./gradlew clean build --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68db49de54008327a0b7e392fe26ee13