### PR TITLE
Fix mixin paths and add validation task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,6 +183,17 @@ tasks.register("validateModVersion") {
     }
 }
 
+tasks.register("validateMixinPaths") {
+    doLast {
+        fileTree("versions").matching { include("**/*.mixins.json") }.forEach { f ->
+            val text = f.readText()
+            if (text.contains("dev.worldgen")) {
+                throw GradleException("Invalid mixin path found in $f: contains 'dev.worldgen'")
+            }
+        }
+    }
+}
+
 if (name == "1.21.1-neoforge" || name == "1.21.5-neoforge") {
     val mcVersion = property("deps.minecraft") as String
 
@@ -268,4 +279,5 @@ publishMods {
 
 tasks.named("build") {
     dependsOn("validateModVersion")
+    dependsOn("validateMixinPaths")
 }

--- a/versions/1.21.1-neoforge/src/main/resources/theexpanse_1.21.1.mixins.json
+++ b/versions/1.21.1-neoforge/src/main/resources/theexpanse_1.21.1.mixins.json
@@ -1,5 +1,5 @@
 {
-  "package": "dev.worldgen.theexpanse.mixin",
+  "package": "com.cyberday1.theexpanse.mixin",
   "required": true,
   "minVersion": "0.8",
   "injectors": {

--- a/versions/1.21.5-neoforge/src/main/resources/theexpanse_1.21.5.mixins.json
+++ b/versions/1.21.5-neoforge/src/main/resources/theexpanse_1.21.5.mixins.json
@@ -1,5 +1,5 @@
 {
-  "package": "dev.worldgen.theexpanse.mixin",
+  "package": "com.cyberday1.theexpanse.mixin",
   "required": true,
   "minVersion": "0.8",
   "injectors": {


### PR DESCRIPTION
## Summary
- correct mixin configuration packages to the com.cyberday1 namespace
- add a Gradle validation task to fail builds when dev.worldgen paths appear in mixin configs

## Testing
- ./gradlew validateMixinPaths

------
https://chatgpt.com/codex/tasks/task_e_68db55600fc083279cacfbd8770c5889