### PR TITLE
Use supported ChunkAccess heightmap API

### DIFF
--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/HeightmapMixin.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/HeightmapMixin.java
@@ -12,9 +12,9 @@ public abstract class HeightmapMixin {
     // CUSTOM: extended vertical range (heightmap)
     @Redirect(method = "primeHeightmaps", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/chunk/ChunkAccess;getHighestSectionPosition()I"))
     private static int theexpanse$extendHeightmapTop(ChunkAccess chunkAccess) {
-        int vanillaTop = chunkAccess.getHighestSectionPosition();
-        int customTop = WorldgenConstants.OVERWORLD_MAX_Y + 1;
         LevelHeightAccessorExtension accessor = (LevelHeightAccessorExtension) chunkAccess;
+        int vanillaTop = accessor.getMaxSectionY();
+        int customTop = WorldgenConstants.OVERWORLD_MAX_Y + 1;
         int minY = accessor.getMinY();
         if (theexpanse$shouldExtendTop(accessor, minY)) {
             return Math.max(vanillaTop, customTop);

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/LevelHeightAccessorExtension.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/LevelHeightAccessorExtension.java
@@ -5,8 +5,19 @@ package com.cyberday1.theexpanse.mixin;
  * the existing LevelHeightAccessor type. Implemented via mixin to keep call sites using the
  * new {@code getMinY}/{@code getMaxY} contract without introducing reflection.
  */
+import net.minecraft.core.SectionPos;
+import net.minecraft.world.level.LevelHeightAccessor;
+
 public interface LevelHeightAccessorExtension {
     int getMinY();
 
     int getMaxY();
+
+    /**
+     * Mirrors the NeoForge 1.21.x {@code ChunkAccess#getMaxSectionY()} API for versions that
+     * still compile against the legacy {@code getHighestSectionPosition()} method.
+     */
+    default int getMaxSectionY() {
+        return SectionPos.sectionToBlockCoord(((LevelHeightAccessor) this).getMaxSection());
+    }
 }


### PR DESCRIPTION
## Summary
- adjust the heightmap mixin to compute the vanilla top using the modern `getMaxSectionY` bridge instead of the deprecated `getHighestSectionPosition`
- extend `LevelHeightAccessorExtension` with a default implementation of `getMaxSectionY` that mirrors NeoForge 1.21.x behaviour

## Testing
- ./gradlew clean build --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbda8c32788327aa0ef492806daecd