### PR TITLE
Add mixin compatibility validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.apache.commons.lang3.StringUtils
+import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.bundling.Zip
@@ -156,6 +157,24 @@ tasks {
     modstitch.finalJarTask {
         archiveVersion.set("${modVersion}+mc${minecraft}-neoforge")
     }
+}
+
+val validateMixinCompatLevels = tasks.register("validateMixinCompatLevels") {
+    doLast {
+        fileTree(".") {
+            include("**/*.mixins.json")
+            exclude("**/build/**")
+        }.forEach { f ->
+            val text = f.readText()
+            if (text.contains("\"JAVA_17\"") || text.contains("\"JAVA_18\"")) {
+                throw GradleException("Invalid mixin compat level in $f. Must be JAVA_21")
+            }
+        }
+    }
+}
+
+tasks.named("build") {
+    dependsOn(validateMixinCompatLevels)
 }
 
 tasks.register("validateModVersion") {


### PR DESCRIPTION
## Summary
- add a Gradle task that scans mixin configuration files and enforces Java 21 compatibility levels
- wire the validation task into the build to catch outdated compatibility levels automatically

## Testing
- ./gradlew validateMixinCompatLevels

------
https://chatgpt.com/codex/tasks/task_e_68dbdf028500832785cbbdaa8684ab5f