### PR TITLE
Vendor Lithostitched functionality

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,8 +134,6 @@ stonecutter {
 // If you want to create proxy configurations for more source sets, such as client source sets,
 // use the modstitch.createProxyConfigurations(sourceSets["client"]) function.
 dependencies {
-    modstitchModImplementation("maven.modrinth:lithostitched:${property("deps.lithostitched")}")
-
     //modstitchModImplementation("maven.modrinth:terralith:${property("deps.terralith")}")
     //modstitchModImplementation("maven.modrinth:clifftree:${property("deps.clifftree")}")
 }
@@ -175,6 +173,7 @@ val validateMixinCompatLevels = tasks.register("validateMixinCompatLevels") {
 
 tasks.named("build") {
     dependsOn(validateMixinCompatLevels)
+    dependsOn(validateNoLithoImports)
 }
 
 tasks.register("validateModVersion") {
@@ -213,6 +212,21 @@ tasks.register("validateMixinPaths") {
                 throw GradleException("Invalid mixin path found in $f: contains 'dev.worldgen'")
             }
         }
+    }
+}
+
+val validateNoLithoImports = tasks.register("validateNoLithoImports") {
+    doLast {
+        fun checkTree(root: String) {
+            fileTree(root).matching { include("**/*.java") }.forEach { file ->
+                if (file.readText().contains("net.lithostitched")) {
+                    throw GradleException("Unexpected net.lithostitched import in $file")
+                }
+            }
+        }
+
+        checkTree("src")
+        checkTree("versions")
     }
 }
 

--- a/versions/1.21.1-neoforge/gradle.properties
+++ b/versions/1.21.1-neoforge/gradle.properties
@@ -3,6 +3,5 @@ modstitch.platform=moddevgradle
 deps.minecraft=1.21.1
 deps.neoforge=21.1.209
 deps.neoform=1.21.1-20240808.144430
-deps.lithostitched=1.4.5-neoforge-1.21
 deps.terralith=MuJMtPGQ
 deps.clifftree=2.0.1+mod

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/LithoCommon.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/LithoCommon.java
@@ -1,0 +1,27 @@
+package com.cyberday1.theexpanse.litho;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class LithoCommon {
+    public static final String NAMESPACE = "lithostitched";
+    private static final Logger LOGGER = LoggerFactory.getLogger("TheExpanseLitho");
+
+    private LithoCommon() {
+    }
+
+    public static ResourceLocation id(String path) {
+        return ResourceLocation.fromNamespaceAndPath(NAMESPACE, path);
+    }
+
+    public static <T> ResourceKey<T> createResourceKey(ResourceKey<? extends Registry<T>> registry, String name) {
+        return ResourceKey.create(registry, id(name));
+    }
+
+    public static void debug(String message, Object... arguments) {
+        LOGGER.debug(message, arguments);
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/LithoRegistries.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/LithoRegistries.java
@@ -1,0 +1,80 @@
+package com.cyberday1.theexpanse.litho;
+
+import com.cyberday1.theexpanse.litho.registry.LithoNeoforgeBiomeModifiers;
+import com.cyberday1.theexpanse.litho.registry.LithoRegistryKeys;
+import com.cyberday1.theexpanse.litho.worldgen.densityfunction.MergedDensityFunction;
+import com.cyberday1.theexpanse.litho.worldgen.densityfunction.OriginalMarkerDensityFunction;
+import com.cyberday1.theexpanse.litho.worldgen.densityfunction.WrappedMarkerDensityFunction;
+import com.cyberday1.theexpanse.litho.worldgen.modifier.AddFeaturesModifier;
+import com.cyberday1.theexpanse.litho.worldgen.modifier.Modifier;
+import com.cyberday1.theexpanse.litho.worldgen.modifier.ReplaceClimateModifier;
+import com.cyberday1.theexpanse.litho.worldgen.modifier.WrapDensityFunctionModifier;
+import com.cyberday1.theexpanse.litho.worldgen.placementcondition.PlacementCondition;
+import com.cyberday1.theexpanse.litho.worldgen.placementcondition.SampleDensityPlacementCondition;
+import com.cyberday1.theexpanse.litho.worldgen.placementmodifier.ConditionPlacement;
+import com.cyberday1.theexpanse.litho.worldgen.placementmodifier.NoiseSlopePlacement;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.common.world.BiomeModifier;
+import net.neoforged.neoforge.registries.DataPackRegistryEvent;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.registries.RegisterEvent;
+
+import java.util.function.BiConsumer;
+
+public final class LithoRegistries {
+    private static final DeferredRegister<MapCodec<? extends Modifier>> MODIFIER_TYPES = DeferredRegister.create(LithoRegistryKeys.MODIFIER_TYPE, LithoCommon.NAMESPACE);
+    private static final DeferredRegister<MapCodec<? extends PlacementCondition>> PLACEMENT_CONDITION_TYPES = DeferredRegister.create(LithoRegistryKeys.PLACEMENT_CONDITION_TYPE, LithoCommon.NAMESPACE);
+    private static final DeferredRegister<MapCodec<? extends BiomeModifier>> BIOME_MODIFIER_TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.BIOME_MODIFIER_SERIALIZERS, LithoCommon.NAMESPACE);
+
+    private LithoRegistries() {
+    }
+
+    public static void init(IEventBus bus) {
+        bus.addListener(LithoRegistries::registerVanillaRegistries);
+        bus.addListener((DataPackRegistryEvent.NewRegistry event) -> event.dataPackRegistry(LithoRegistryKeys.WORLDGEN_MODIFIER, Modifier.CODEC));
+
+        registerModifiers((name, codec) -> MODIFIER_TYPES.register(name, () -> codec));
+        registerPlacementConditions((name, codec) -> PLACEMENT_CONDITION_TYPES.register(name, () -> codec));
+        registerBiomeModifiers((name, codec) -> BIOME_MODIFIER_TYPES.register(name, () -> codec));
+
+        MODIFIER_TYPES.register(bus);
+        PLACEMENT_CONDITION_TYPES.register(bus);
+        BIOME_MODIFIER_TYPES.register(bus);
+    }
+
+    private static void registerModifiers(BiConsumer<String, MapCodec<? extends Modifier>> consumer) {
+        consumer.accept("wrap_density_function", WrapDensityFunctionModifier.CODEC);
+        consumer.accept("add_features", AddFeaturesModifier.CODEC);
+        consumer.accept("replace_climate", ReplaceClimateModifier.CODEC);
+    }
+
+    private static void registerPlacementConditions(BiConsumer<String, MapCodec<? extends PlacementCondition>> consumer) {
+        consumer.accept("sample_density", SampleDensityPlacementCondition.CODEC);
+    }
+
+    private static void registerBiomeModifiers(BiConsumer<String, MapCodec<? extends BiomeModifier>> consumer) {
+        consumer.accept("replace_climate", LithoNeoforgeBiomeModifiers.ReplaceClimateBiomeModifier.CODEC);
+    }
+
+    private static void registerVanillaRegistries(RegisterEvent event) {
+        event.register(Registries.PLACEMENT_MODIFIER_TYPE, helper -> {
+            helper.register(createKey(Registries.PLACEMENT_MODIFIER_TYPE, "condition"), ConditionPlacement.TYPE);
+            helper.register(createKey(Registries.PLACEMENT_MODIFIER_TYPE, "noise_slope"), NoiseSlopePlacement.TYPE);
+        });
+
+        event.register(Registries.DENSITY_FUNCTION_TYPE, helper -> {
+            helper.register(createKey(Registries.DENSITY_FUNCTION_TYPE, "internal/merged"), MergedDensityFunction.CODEC.codec());
+            helper.register(createKey(Registries.DENSITY_FUNCTION_TYPE, "wrapped_marker"), WrappedMarkerDensityFunction.CODEC.codec());
+            helper.register(createKey(Registries.DENSITY_FUNCTION_TYPE, "original_marker"), OriginalMarkerDensityFunction.CODEC.codec());
+        });
+    }
+
+    private static <T> ResourceKey<T> createKey(ResourceKey<? extends Registry<T>> registry, String name) {
+        return LithoCommon.createResourceKey(registry, name);
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/registry/LithoNeoforgeBiomeModifiers.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/registry/LithoNeoforgeBiomeModifiers.java
@@ -1,0 +1,38 @@
+package com.cyberday1.theexpanse.litho.registry;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.world.level.biome.Biome;
+import net.neoforged.neoforge.common.world.BiomeModifier;
+import net.neoforged.neoforge.common.world.ClimateSettingsBuilder;
+import net.neoforged.neoforge.common.world.ModifiableBiomeInfo;
+
+public final class LithoNeoforgeBiomeModifiers {
+    private LithoNeoforgeBiomeModifiers() {
+    }
+
+    public record ReplaceClimateBiomeModifier(HolderSet<Biome> biomes, Biome.ClimateSettings climateSettings) implements BiomeModifier {
+        public static final MapCodec<ReplaceClimateBiomeModifier> CODEC = RecordCodecBuilder.mapCodec(builder -> builder.group(
+            Biome.LIST_CODEC.fieldOf("biomes").forGetter(ReplaceClimateBiomeModifier::biomes),
+            Biome.ClimateSettings.CODEC.fieldOf("climate").forGetter(ReplaceClimateBiomeModifier::climateSettings)
+        ).apply(builder, ReplaceClimateBiomeModifier::new));
+
+        @Override
+        public void modify(Holder<Biome> biome, Phase phase, ModifiableBiomeInfo.BiomeInfo.Builder builder) {
+            if (phase == Phase.MODIFY && this.biomes.contains(biome)) {
+                ClimateSettingsBuilder climateSettings = builder.getClimateSettings();
+                climateSettings.setTemperature(this.climateSettings.temperature());
+                climateSettings.setDownfall(this.climateSettings.downfall());
+                climateSettings.setHasPrecipitation(this.climateSettings.hasPrecipitation());
+                climateSettings.setTemperatureModifier(this.climateSettings.temperatureModifier());
+            }
+        }
+
+        @Override
+        public MapCodec<? extends BiomeModifier> codec() {
+            return CODEC;
+        }
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/registry/LithoRegistryKeys.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/registry/LithoRegistryKeys.java
@@ -1,0 +1,20 @@
+package com.cyberday1.theexpanse.litho.registry;
+
+import com.cyberday1.theexpanse.litho.LithoCommon;
+import com.cyberday1.theexpanse.litho.worldgen.modifier.Modifier;
+import com.cyberday1.theexpanse.litho.worldgen.placementcondition.PlacementCondition;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+
+public final class LithoRegistryKeys {
+    public static final ResourceKey<Registry<Modifier>> WORLDGEN_MODIFIER = create("worldgen_modifier");
+    public static final ResourceKey<Registry<com.mojang.serialization.MapCodec<? extends Modifier>>> MODIFIER_TYPE = create("modifier_type");
+    public static final ResourceKey<Registry<com.mojang.serialization.MapCodec<? extends PlacementCondition>>> PLACEMENT_CONDITION_TYPE = create("placement_condition_type");
+
+    private LithoRegistryKeys() {
+    }
+
+    private static <T> ResourceKey<Registry<T>> create(String name) {
+        return ResourceKey.createRegistryKey(LithoCommon.id(name));
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/densityfunction/MarkerFunction.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/densityfunction/MarkerFunction.java
@@ -1,0 +1,20 @@
+package com.cyberday1.theexpanse.litho.worldgen.densityfunction;
+
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public interface MarkerFunction extends DensityFunction.SimpleFunction {
+    @Override
+    default double compute(FunctionContext context) {
+        throw new IllegalStateException("Marker density function should never be computed!");
+    }
+
+    @Override
+    default double minValue() {
+        return 0;
+    }
+
+    @Override
+    default double maxValue() {
+        return 0;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/densityfunction/MergedDensityFunction.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/densityfunction/MergedDensityFunction.java
@@ -1,0 +1,49 @@
+package com.cyberday1.theexpanse.litho.worldgen.densityfunction;
+
+import net.minecraft.util.KeyDispatchDataCodec;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+import org.jetbrains.annotations.NotNull;
+
+public record MergedDensityFunction(DensityFunction original, DensityFunction wrapped, DensityFunction full) implements DensityFunction {
+    public static final KeyDispatchDataCodec<DensityFunction> CODEC = KeyDispatchDataCodec.of(
+        HOLDER_HELPER_CODEC.xmap(
+            df -> df instanceof DensityFunctions.HolderHolder holder ? holder.function().value() : df,
+            MergedDensityFunction::unwrappedOriginal
+        ).fieldOf("original")
+    );
+
+    private static DensityFunction unwrappedOriginal(DensityFunction function) {
+        return function instanceof MergedDensityFunction merged ? unwrappedOriginal(merged.original()) : function;
+    }
+
+    @Override
+    public double compute(FunctionContext context) {
+        return this.full.compute(context);
+    }
+
+    @Override
+    public void fillArray(double[] samples, ContextProvider contextProvider) {
+        this.full.fillArray(samples, contextProvider);
+    }
+
+    @Override
+    public DensityFunction mapAll(Visitor visitor) {
+        return this.full.mapAll(visitor);
+    }
+
+    @Override
+    public double minValue() {
+        return this.full.minValue();
+    }
+
+    @Override
+    public double maxValue() {
+        return this.full.maxValue();
+    }
+
+    @Override
+    public @NotNull KeyDispatchDataCodec<? extends DensityFunction> codec() {
+        return CODEC;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/densityfunction/OriginalMarkerDensityFunction.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/densityfunction/OriginalMarkerDensityFunction.java
@@ -1,0 +1,15 @@
+package com.cyberday1.theexpanse.litho.worldgen.densityfunction;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.util.KeyDispatchDataCodec;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import org.jetbrains.annotations.NotNull;
+
+public final class OriginalMarkerDensityFunction implements MarkerFunction {
+    public static final KeyDispatchDataCodec<OriginalMarkerDensityFunction> CODEC = KeyDispatchDataCodec.of(MapCodec.unit(new OriginalMarkerDensityFunction()));
+
+    @Override
+    public @NotNull KeyDispatchDataCodec<? extends DensityFunction> codec() {
+        return CODEC;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/densityfunction/WrappedMarkerDensityFunction.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/densityfunction/WrappedMarkerDensityFunction.java
@@ -1,0 +1,15 @@
+package com.cyberday1.theexpanse.litho.worldgen.densityfunction;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.util.KeyDispatchDataCodec;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import org.jetbrains.annotations.NotNull;
+
+public final class WrappedMarkerDensityFunction implements MarkerFunction {
+    public static final KeyDispatchDataCodec<WrappedMarkerDensityFunction> CODEC = KeyDispatchDataCodec.of(MapCodec.unit(new WrappedMarkerDensityFunction()));
+
+    @Override
+    public @NotNull KeyDispatchDataCodec<? extends DensityFunction> codec() {
+        return CODEC;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/AbstractBiomeModifier.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/AbstractBiomeModifier.java
@@ -1,0 +1,24 @@
+package com.cyberday1.theexpanse.litho.worldgen.modifier;
+
+import net.neoforged.neoforge.common.world.BiomeModifier;
+
+public abstract class AbstractBiomeModifier implements Modifier {
+    private final BiomeModifier neoforgeBiomeModifier;
+
+    protected AbstractBiomeModifier(BiomeModifier neoforgeBiomeModifier) {
+        this.neoforgeBiomeModifier = neoforgeBiomeModifier;
+    }
+
+    public BiomeModifier neoforgeBiomeModifier() {
+        return this.neoforgeBiomeModifier;
+    }
+
+    @Override
+    public ModifierPhase getPhase() {
+        return ModifierPhase.NONE;
+    }
+
+    @Override
+    public void applyModifier() {
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/AddFeaturesModifier.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/AddFeaturesModifier.java
@@ -1,0 +1,45 @@
+package com.cyberday1.theexpanse.litho.worldgen.modifier;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.neoforged.neoforge.common.world.BiomeModifiers;
+
+public final class AddFeaturesModifier extends AbstractBiomeModifier {
+    public static final MapCodec<AddFeaturesModifier> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        Biome.LIST_CODEC.fieldOf("biomes").forGetter(AddFeaturesModifier::biomes),
+        PlacedFeature.LIST_CODEC.fieldOf("features").forGetter(AddFeaturesModifier::features),
+        GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(AddFeaturesModifier::step)
+    ).apply(instance, AddFeaturesModifier::new));
+
+    private final HolderSet<Biome> biomes;
+    private final HolderSet<PlacedFeature> features;
+    private final GenerationStep.Decoration step;
+
+    public AddFeaturesModifier(HolderSet<Biome> biomes, HolderSet<PlacedFeature> features, GenerationStep.Decoration step) {
+        super(new BiomeModifiers.AddFeaturesBiomeModifier(biomes, features, step));
+        this.biomes = biomes;
+        this.features = features;
+        this.step = step;
+    }
+
+    public HolderSet<Biome> biomes() {
+        return this.biomes;
+    }
+
+    public HolderSet<PlacedFeature> features() {
+        return this.features;
+    }
+
+    public GenerationStep.Decoration step() {
+        return this.step;
+    }
+
+    @Override
+    public MapCodec<? extends Modifier> codec() {
+        return CODEC;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/Modifier.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/Modifier.java
@@ -1,0 +1,116 @@
+package com.cyberday1.theexpanse.litho.worldgen.modifier;
+
+import com.cyberday1.theexpanse.litho.LithoCommon;
+import com.cyberday1.theexpanse.litho.registry.LithoRegistryKeys;
+import com.cyberday1.theexpanse.mixin.litho.access.ChunkGeneratorAccessor;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.biome.FeatureSorter;
+import net.minecraft.world.level.dimension.LevelStem;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+
+public interface Modifier {
+    @SuppressWarnings("unchecked")
+    com.mojang.serialization.Codec<Modifier> CODEC = com.mojang.serialization.Codec.lazyInitialized(() -> {
+        var modifierRegistry = BuiltInRegistries.REGISTRY.get(LithoRegistryKeys.MODIFIER_TYPE.location());
+        if (modifierRegistry == null) throw new NullPointerException("Worldgen modifier registry does not exist yet!");
+        return ((Registry<com.mojang.serialization.MapCodec<? extends Modifier>>) modifierRegistry).byNameCodec();
+    }).dispatch(Modifier::codec, Function.identity());
+
+    default void applyModifier(RegistryAccess registryAccess) {
+        this.applyModifier();
+    }
+
+    void applyModifier();
+
+    ModifierPhase getPhase();
+
+    com.mojang.serialization.MapCodec<? extends Modifier> codec();
+
+    static void applyModifiers(MinecraftServer server) {
+        boolean updatedFeatures = false;
+        RegistryAccess registries = server.registryAccess();
+        HolderLookup.RegistryLookup<Modifier> modifiers = registries.lookupOrThrow(LithoRegistryKeys.WORLDGEN_MODIFIER);
+
+        for (ModifierPhase phase : ModifierPhase.values()) {
+            if (phase == ModifierPhase.NONE) continue;
+            List<Holder.Reference<Modifier>> phaseModifiers = modifiers.listElements()
+                .filter(holder -> holder.value().getPhase() == phase)
+                .toList();
+            applyPhaseModifiers(registries, phaseModifiers);
+
+            if (phaseModifiers.stream().anyMatch(holder -> holder.value().internal$modifiesFabricFeatures())) {
+                updatedFeatures = true;
+            }
+        }
+
+        if (updatedFeatures) {
+            Registry<LevelStem> dimensions = registries.registryOrThrow(Registries.LEVEL_STEM);
+            for (LevelStem dimension : dimensions) {
+                ChunkGeneratorAccessor accessor = (ChunkGeneratorAccessor) dimension.generator();
+                BiomeSource source = accessor.getBiomeSource();
+                accessor.setFeaturesPerStep(() -> FeatureSorter.buildFeaturesPerStep(List.copyOf(source.possibleBiomes()),
+                    biome -> accessor.getGetter().apply(biome).features(), true));
+            }
+        }
+    }
+
+    private static void applyPhaseModifiers(RegistryAccess registries, List<Holder.Reference<Modifier>> phaseModifiers) {
+        List<Holder.Reference<PriorityBasedModifier>> priorityBased = new ArrayList<>();
+
+        for (Holder.Reference<Modifier> reference : phaseModifiers) {
+            if (reference.value() instanceof PriorityBasedModifier priority) {
+                priorityBased.add((Holder.Reference<PriorityBasedModifier>) (Object) reference);
+            } else {
+                LithoCommon.debug("Applying modifier with id: {}", reference.key().location());
+                reference.value().applyModifier(registries);
+            }
+        }
+
+        for (Holder.Reference<PriorityBasedModifier> reference : sortByPriority(priorityBased)) {
+            LithoCommon.debug("Applying modifier with id: {}", reference.key().location());
+            reference.value().applyModifier(registries);
+        }
+    }
+
+    static List<Holder.Reference<PriorityBasedModifier>> sortByPriority(List<Holder.Reference<PriorityBasedModifier>> modifiers) {
+        return modifiers.stream().sorted(Comparator.comparingInt(reference -> reference.value().getPriority())).toList();
+    }
+
+    default boolean internal$modifiesFabricFeatures() {
+        return false;
+    }
+
+    enum ModifierPhase implements StringRepresentable {
+        NONE("none"),
+        BEFORE_ALL("before_all"),
+        REPLACE("replace"),
+        ADD("add"),
+        REMOVE("remove"),
+        MODIFY("modify"),
+        AFTER_ALL("after_all");
+
+        private final String name;
+
+        ModifierPhase(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public @NotNull String getSerializedName() {
+            return this.name;
+        }
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/PriorityBasedModifier.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/PriorityBasedModifier.java
@@ -1,0 +1,10 @@
+package com.cyberday1.theexpanse.litho.worldgen.modifier;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.util.ExtraCodecs;
+
+public interface PriorityBasedModifier extends Modifier {
+    MapCodec<Integer> PRIORITY_CODEC = ExtraCodecs.NON_NEGATIVE_INT.optionalFieldOf("priority", 1000);
+
+    int getPriority();
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/ReplaceClimateModifier.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/ReplaceClimateModifier.java
@@ -1,0 +1,36 @@
+package com.cyberday1.theexpanse.litho.worldgen.modifier;
+
+import com.cyberday1.theexpanse.litho.registry.LithoNeoforgeBiomeModifiers;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.world.level.biome.Biome;
+
+public final class ReplaceClimateModifier extends AbstractBiomeModifier {
+    public static final MapCodec<ReplaceClimateModifier> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        Biome.LIST_CODEC.fieldOf("biomes").forGetter(ReplaceClimateModifier::biomes),
+        Biome.ClimateSettings.CODEC.fieldOf("climate").forGetter(ReplaceClimateModifier::climateSettings)
+    ).apply(instance, ReplaceClimateModifier::new));
+
+    private final HolderSet<Biome> biomes;
+    private final Biome.ClimateSettings climateSettings;
+
+    public ReplaceClimateModifier(HolderSet<Biome> biomes, Biome.ClimateSettings climateSettings) {
+        super(new LithoNeoforgeBiomeModifiers.ReplaceClimateBiomeModifier(biomes, climateSettings));
+        this.biomes = biomes;
+        this.climateSettings = climateSettings;
+    }
+
+    public HolderSet<Biome> biomes() {
+        return this.biomes;
+    }
+
+    public Biome.ClimateSettings climateSettings() {
+        return this.climateSettings;
+    }
+
+    @Override
+    public MapCodec<? extends Modifier> codec() {
+        return CODEC;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/WrapDensityFunctionModifier.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/WrapDensityFunctionModifier.java
@@ -1,0 +1,45 @@
+package com.cyberday1.theexpanse.litho.worldgen.modifier;
+
+import com.cyberday1.theexpanse.mixin.litho.access.HolderReferenceAccessor;
+import com.cyberday1.theexpanse.litho.worldgen.modifier.util.DensityFunctionWrapper;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.RegistryFileCodec;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public record WrapDensityFunctionModifier(int priority, Holder<DensityFunction> targetFunction, Holder<DensityFunction> wrapperFunction) implements PriorityBasedModifier {
+    private static final Codec<Holder<DensityFunction>> DF_REFERENCE_CODEC = RegistryFileCodec.create(Registries.DENSITY_FUNCTION, DensityFunction.DIRECT_CODEC, false);
+
+    public static final MapCodec<WrapDensityFunctionModifier> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        PRIORITY_CODEC.forGetter(WrapDensityFunctionModifier::priority),
+        DF_REFERENCE_CODEC.fieldOf("target_function").forGetter(WrapDensityFunctionModifier::targetFunction),
+        DensityFunction.CODEC.fieldOf("wrapper_function").forGetter(WrapDensityFunctionModifier::wrapperFunction)
+    ).apply(instance, WrapDensityFunctionModifier::new));
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void applyModifier() {
+        if (this.targetFunction instanceof Holder.Reference<DensityFunction> reference) {
+            HolderReferenceAccessor<DensityFunction> accessor = (HolderReferenceAccessor<DensityFunction>) reference;
+            accessor.setValue(DensityFunctionWrapper.wrap(this.targetFunction.value(), this.wrapperFunction.value()));
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        return this.priority;
+    }
+
+    @Override
+    public ModifierPhase getPhase() {
+        return ModifierPhase.MODIFY;
+    }
+
+    @Override
+    public MapCodec<? extends Modifier> codec() {
+        return CODEC;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/util/DensityFunctionWrapper.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/modifier/util/DensityFunctionWrapper.java
@@ -1,0 +1,38 @@
+package com.cyberday1.theexpanse.litho.worldgen.modifier.util;
+
+import com.cyberday1.theexpanse.litho.worldgen.densityfunction.MarkerFunction;
+import com.cyberday1.theexpanse.litho.worldgen.densityfunction.MergedDensityFunction;
+import com.cyberday1.theexpanse.litho.worldgen.densityfunction.OriginalMarkerDensityFunction;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+
+public final class DensityFunctionWrapper {
+    private DensityFunctionWrapper() {
+    }
+
+    public static DensityFunction wrap(DensityFunction wrapped, DensityFunction wrapper) {
+        if (wrapped instanceof MergedDensityFunction merged) {
+            DensityFunction original = merged.original();
+            return new MergedDensityFunction(original, wrapped, wrapper.mapAll(value -> {
+                if (isMarker(value)) {
+                    if (value instanceof OriginalMarkerDensityFunction) {
+                        return original;
+                    }
+                    return wrapped;
+                }
+                return value;
+            }));
+        }
+
+        return new MergedDensityFunction(wrapped, wrapped, wrapper.mapAll(value -> {
+            if (isMarker(value)) {
+                return wrapped;
+            }
+            return value;
+        }));
+    }
+
+    private static boolean isMarker(DensityFunction function) {
+        return function instanceof DensityFunctions.HolderHolder holder && holder.function().value() instanceof MarkerFunction;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementcondition/AllOfPlacementCondition.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementcondition/AllOfPlacementCondition.java
@@ -1,0 +1,40 @@
+package com.cyberday1.theexpanse.litho.worldgen.placementcondition;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class AllOfPlacementCondition implements PlacementCondition {
+    public static final MapCodec<AllOfPlacementCondition> CODEC = PlacementCondition.BASE_CODEC.listOf().fieldOf("conditions").xmap(AllOfPlacementCondition::new, AllOfPlacementCondition::conditions);
+
+    private final List<PlacementCondition> conditions;
+
+    public AllOfPlacementCondition(List<PlacementCondition> conditions) {
+        this.conditions = new ArrayList<>(conditions);
+    }
+
+    public List<PlacementCondition> conditions() {
+        return this.conditions;
+    }
+
+    public void appendCondition(PlacementCondition condition) {
+        this.conditions.add(condition);
+    }
+
+    @Override
+    public boolean test(Context context, BlockPos pos) {
+        for (PlacementCondition condition : this.conditions) {
+            if (!condition.test(context, pos)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public MapCodec<? extends PlacementCondition> codec() {
+        return CODEC;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementcondition/PlacementCondition.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementcondition/PlacementCondition.java
@@ -1,0 +1,53 @@
+package com.cyberday1.theexpanse.litho.worldgen.placementcondition;
+
+import com.cyberday1.theexpanse.litho.registry.LithoRegistryKeys;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.LevelHeightAccessor;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.levelgen.RandomState;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.structure.Structure;
+
+import java.util.function.Function;
+
+public interface PlacementCondition {
+    @SuppressWarnings("unchecked")
+    Codec<PlacementCondition> BASE_CODEC = Codec.lazyInitialized(() -> {
+        var registry = BuiltInRegistries.REGISTRY.get(LithoRegistryKeys.PLACEMENT_CONDITION_TYPE.location());
+        if (registry == null) throw new NullPointerException("Placement condition registry does not exist yet!");
+        return ((Registry<MapCodec<? extends PlacementCondition>>) registry).byNameCodec();
+    }).dispatch(PlacementCondition::codec, Function.identity());
+
+    Codec<PlacementCondition> CODEC = Codec.withAlternative(BASE_CODEC, BASE_CODEC.listOf(), AllOfPlacementCondition::new);
+
+    boolean test(Context context, BlockPos pos);
+
+    default boolean test(Structure.GenerationContext context, BlockPos pos) {
+        return this.test(Context.create(context), pos);
+    }
+
+    default boolean test(PlacementContext context, BlockPos pos) {
+        return this.test(Context.create(context), pos);
+    }
+
+    MapCodec<? extends PlacementCondition> codec();
+
+    record Context(RegistryAccess registries, ChunkGenerator generator, LevelHeightAccessor heightAccessor,
+                   RandomState randomState, BiomeSource biomeSource, long seed) {
+        private static Context create(Structure.GenerationContext context) {
+            return new Context(context.registryAccess(), context.chunkGenerator(), context.heightAccessor(), context.randomState(), context.biomeSource(), context.seed());
+        }
+
+        private static Context create(PlacementContext context) {
+            WorldGenLevel level = context.getLevel();
+            return new Context(level.registryAccess(), context.generator(), level, level.getLevel().getChunkSource().randomState(), context.generator().getBiomeSource(), level.getSeed());
+        }
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementcondition/SampleDensityPlacementCondition.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementcondition/SampleDensityPlacementCondition.java
@@ -1,0 +1,107 @@
+package com.cyberday1.theexpanse.litho.worldgen.placementcondition;
+
+import com.cyberday1.theexpanse.mixin.litho.access.RandomStateAccessor;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.*;
+import net.minecraft.world.level.levelgen.structure.Structure;
+import net.minecraft.world.level.levelgen.synth.BlendedNoise;
+import net.minecraft.world.level.levelgen.synth.NormalNoise;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public record SampleDensityPlacementCondition(Holder<DensityFunction> densityFunction, Optional<Double> minInclusive, Optional<Double> maxInclusive) implements PlacementCondition {
+    public static final MapCodec<SampleDensityPlacementCondition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        DensityFunction.CODEC.fieldOf("density_function").forGetter(SampleDensityPlacementCondition::densityFunction),
+        Codec.DOUBLE.optionalFieldOf("min_inclusive").forGetter(SampleDensityPlacementCondition::minInclusive),
+        Codec.DOUBLE.optionalFieldOf("max_inclusive").forGetter(SampleDensityPlacementCondition::maxInclusive)
+    ).apply(instance, SampleDensityPlacementCondition::new));
+
+    @Override
+    public boolean test(Context context, BlockPos pos) {
+        if (!(context.generator() instanceof NoiseBasedChunkGenerator chunkGenerator)) {
+            return false;
+        }
+
+        DensityFunction df = this.densityFunction.value().mapAll(new NoiseWiringHelper(
+            context.seed(),
+            chunkGenerator.generatorSettings().value().useLegacyRandomSource(),
+            context.randomState(),
+            ((RandomStateAccessor) (Object) context.randomState()).getRandom()
+        ));
+        double density = df.compute(new DensityFunction.SinglePointContext(pos.getX(), pos.getY(), pos.getZ()));
+
+        boolean min = this.minInclusive.isEmpty() || density >= this.minInclusive.get();
+        boolean max = this.maxInclusive.isEmpty() || density <= this.maxInclusive.get();
+        return min && max;
+    }
+
+    @Override
+    public MapCodec<? extends PlacementCondition> codec() {
+        return CODEC;
+    }
+
+    private static final class NoiseWiringHelper implements DensityFunction.Visitor {
+        private final Map<DensityFunction, DensityFunction> wrapped = new HashMap<>();
+        private final boolean useLegacySource;
+        private final long seed;
+        private final RandomState randomState;
+        private final PositionalRandomFactory random;
+
+        private NoiseWiringHelper(long seed, boolean useLegacySource, RandomState randomState, PositionalRandomFactory random) {
+            this.seed = seed;
+            this.useLegacySource = useLegacySource;
+            this.randomState = randomState;
+            this.random = random;
+        }
+
+        private RandomSource newLegacyInstance(long noiseSeed) {
+            return new LegacyRandomSource(this.seed + noiseSeed);
+        }
+
+        @Override
+        public DensityFunction.NoiseHolder visitNoise(DensityFunction.NoiseHolder noiseHolder) {
+            Holder<NormalNoise.NoiseParameters> noiseData = noiseHolder.noiseData();
+            NormalNoise noise;
+            if (this.useLegacySource) {
+                if (noiseData.is(Noises.TEMPERATURE)) {
+                    noise = NormalNoise.createLegacyNetherBiome(this.newLegacyInstance(0L), new NormalNoise.NoiseParameters(-7, 1.0, new double[]{1.0}));
+                    return new DensityFunction.NoiseHolder(noiseData, noise);
+                }
+
+                if (noiseData.is(Noises.VEGETATION)) {
+                    noise = NormalNoise.createLegacyNetherBiome(this.newLegacyInstance(1L), new NormalNoise.NoiseParameters(-7, 1.0, new double[]{1.0}));
+                    return new DensityFunction.NoiseHolder(noiseData, noise);
+                }
+
+                if (noiseData.is(Noises.SHIFT)) {
+                    noise = NormalNoise.create(this.random.fromHashOf(Noises.SHIFT.location()), new NormalNoise.NoiseParameters(0, 0.0, new double[0]));
+                    return new DensityFunction.NoiseHolder(noiseData, noise);
+                }
+            }
+
+            noise = this.randomState.getOrCreateNoise(noiseData.unwrapKey().orElseThrow());
+            return new DensityFunction.NoiseHolder(noiseData, noise);
+        }
+
+        private DensityFunction wrapNew(DensityFunction densityFunction) {
+            if (densityFunction instanceof BlendedNoise blended) {
+                RandomSource source = this.useLegacySource ? this.newLegacyInstance(0L) : this.random.fromHashOf(ResourceLocation.withDefaultNamespace("terrain"));
+                return blended.withNewRandom(source);
+            }
+            return densityFunction;
+        }
+
+        @Override
+        public DensityFunction apply(DensityFunction densityFunction) {
+            return this.wrapped.computeIfAbsent(densityFunction, this::wrapNew);
+        }
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementmodifier/ConditionPlacement.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementmodifier/ConditionPlacement.java
@@ -1,0 +1,34 @@
+package com.cyberday1.theexpanse.litho.worldgen.placementmodifier;
+
+import com.cyberday1.theexpanse.litho.worldgen.placementcondition.PlacementCondition;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementFilter;
+import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
+
+public final class ConditionPlacement extends PlacementFilter {
+    public static final MapCodec<ConditionPlacement> CODEC = PlacementCondition.CODEC.fieldOf("condition").xmap(ConditionPlacement::new, ConditionPlacement::condition);
+    public static final PlacementModifierType<ConditionPlacement> TYPE = () -> CODEC;
+
+    private final PlacementCondition condition;
+
+    public ConditionPlacement(PlacementCondition condition) {
+        this.condition = condition;
+    }
+
+    public PlacementCondition condition() {
+        return this.condition;
+    }
+
+    @Override
+    protected boolean shouldPlace(PlacementContext context, RandomSource random, BlockPos pos) {
+        return this.condition.test(context, pos);
+    }
+
+    @Override
+    public PlacementModifierType<?> type() {
+        return TYPE;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementmodifier/NoiseSlopePlacement.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/litho/worldgen/placementmodifier/NoiseSlopePlacement.java
@@ -1,0 +1,78 @@
+package com.cyberday1.theexpanse.litho.worldgen.placementmodifier;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.RandomState;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
+import net.minecraft.world.level.levelgen.synth.NormalNoise;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public final class NoiseSlopePlacement extends PlacementModifier {
+    public static final MapCodec<NoiseSlopePlacement> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        ResourceKey.codec(Registries.NOISE).fieldOf("noise").forGetter(NoiseSlopePlacement::noise),
+        Codec.INT.fieldOf("slope").forGetter(NoiseSlopePlacement::slope),
+        Codec.INT.fieldOf("offset").orElse(0).forGetter(NoiseSlopePlacement::offset),
+        Codec.DOUBLE.fieldOf("xz_scale").forGetter(NoiseSlopePlacement::xzScale),
+        Codec.DOUBLE.fieldOf("y_scale").forGetter(NoiseSlopePlacement::yScale)
+    ).apply(instance, NoiseSlopePlacement::new));
+    public static final PlacementModifierType<NoiseSlopePlacement> TYPE = () -> CODEC;
+
+    private final ResourceKey<NormalNoise.NoiseParameters> noise;
+    private final int slope;
+    private final int offset;
+    private final double xzScale;
+    private final double yScale;
+
+    public NoiseSlopePlacement(ResourceKey<NormalNoise.NoiseParameters> noise, int slope, int offset, double xzScale, double yScale) {
+        this.noise = noise;
+        this.slope = slope;
+        this.offset = offset;
+        this.xzScale = xzScale;
+        this.yScale = yScale;
+    }
+
+    public ResourceKey<NormalNoise.NoiseParameters> noise() {
+        return this.noise;
+    }
+
+    public int slope() {
+        return this.slope;
+    }
+
+    public int offset() {
+        return this.offset;
+    }
+
+    public double xzScale() {
+        return this.xzScale;
+    }
+
+    public double yScale() {
+        return this.yScale;
+    }
+
+    @Override
+    public Stream<BlockPos> getPositions(PlacementContext context, RandomSource random, BlockPos pos) {
+        return IntStream.range(0, this.count(context, pos)).mapToObj(__ -> pos);
+    }
+
+    protected int count(PlacementContext context, BlockPos pos) {
+        RandomState state = context.getLevel().getLevel().getChunkSource().randomState();
+        double value = state.getOrCreateNoise(this.noise).getValue(pos.getX() * this.xzScale, pos.getY() * this.yScale, pos.getZ() * this.xzScale);
+        return (int) Math.ceil(value * this.slope) + this.offset;
+    }
+
+    @Override
+    public PlacementModifierType<?> type() {
+        return TYPE;
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/access/ChunkGeneratorAccessor.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/access/ChunkGeneratorAccessor.java
@@ -1,0 +1,28 @@
+package com.cyberday1.theexpanse.mixin.litho.access;
+
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.biome.FeatureSorter;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Mixin(ChunkGenerator.class)
+public interface ChunkGeneratorAccessor {
+    @Accessor("biomeSource")
+    BiomeSource getBiomeSource();
+
+    @Accessor("generationSettingsGetter")
+    Function<Holder<Biome>, BiomeGenerationSettings> getGetter();
+
+    @Accessor("featuresPerStep")
+    @Mutable
+    void setFeaturesPerStep(Supplier<List<FeatureSorter.StepFeatureData>> featuresPerStep);
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/access/HolderReferenceAccessor.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/access/HolderReferenceAccessor.java
@@ -1,0 +1,11 @@
+package com.cyberday1.theexpanse.mixin.litho.access;
+
+import net.minecraft.core.Holder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Holder.Reference.class)
+public interface HolderReferenceAccessor<T> {
+    @Accessor("value")
+    void setValue(T value);
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/access/RandomStateAccessor.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/access/RandomStateAccessor.java
@@ -1,0 +1,14 @@
+package com.cyberday1.theexpanse.mixin.litho.access;
+
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+import net.minecraft.world.level.levelgen.RandomState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(RandomState.class)
+public interface RandomStateAccessor {
+    @Accessor("random")
+    @Mutable
+    PositionalRandomFactory getRandom();
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/client/IntegratedServerMixin.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/client/IntegratedServerMixin.java
@@ -1,0 +1,17 @@
+package com.cyberday1.theexpanse.mixin.litho.client;
+
+import com.cyberday1.theexpanse.litho.worldgen.modifier.Modifier;
+import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(IntegratedServer.class)
+public class IntegratedServerMixin {
+    @Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/server/IntegratedServer;loadLevel()V", shift = At.Shift.BEFORE))
+    private void theexpanse$applyModifiers(CallbackInfoReturnable<Boolean> cir) {
+        Modifier.applyModifiers((MinecraftServer) (Object) this);
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/server/DedicatedServerMixin.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/server/DedicatedServerMixin.java
@@ -1,0 +1,17 @@
+package com.cyberday1.theexpanse.mixin.litho.server;
+
+import com.cyberday1.theexpanse.litho.worldgen.modifier.Modifier;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(DedicatedServer.class)
+public class DedicatedServerMixin {
+    @Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;loadLevel()V", shift = At.Shift.BEFORE), allow = 1)
+    private void theexpanse$applyModifiers(CallbackInfoReturnable<Boolean> cir) {
+        Modifier.applyModifiers((MinecraftServer) (Object) this);
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/server/GameTestServerMixin.java
+++ b/versions/1.21.1-neoforge/src/main/java/com/cyberday1/theexpanse/mixin/litho/server/GameTestServerMixin.java
@@ -1,0 +1,17 @@
+package com.cyberday1.theexpanse.mixin.litho.server;
+
+import com.cyberday1.theexpanse.litho.worldgen.modifier.Modifier;
+import net.minecraft.gametest.framework.GameTestServer;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(GameTestServer.class)
+public class GameTestServerMixin {
+    @Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/gametest/framework/GameTestServer;loadLevel()V", shift = At.Shift.BEFORE))
+    private void theexpanse$applyModifiers(CallbackInfoReturnable<Boolean> cir) {
+        Modifier.applyModifiers((MinecraftServer) (Object) this);
+    }
+}

--- a/versions/1.21.1-neoforge/src/main/java/dev/worldgen/theexpanse/loaders/neoforge/TheExpanseNeoforge.java
+++ b/versions/1.21.1-neoforge/src/main/java/dev/worldgen/theexpanse/loaders/neoforge/TheExpanseNeoforge.java
@@ -1,6 +1,7 @@
 //? if neoforge {
 /*package dev.worldgen.theexpanse.loaders.neoforge;
 
+import com.cyberday1.theexpanse.litho.LithoRegistries;
 import com.mojang.serialization.MapCodec;
 import dev.worldgen.theexpanse.TheExpanse;
 import dev.worldgen.theexpanse.config.ConfigHandler;
@@ -38,6 +39,7 @@ public class TheExpanseNeoforge {
     public TheExpanseNeoforge(IEventBus bus) {
         TheExpanse.init(FMLPaths.CONFIGDIR.get());
 
+        LithoRegistries.init(bus);
         CONDITION_TYPES.register(bus);
 
         bus.addListener(this::registerDensityFunctionTypes);

--- a/versions/1.21.1-neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/versions/1.21.1-neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -23,8 +23,3 @@ license = "MIT"
     type = "required"
     versionRange = "[1.21.1,1.21.2)"
 
-[[dependencies.tectonicexpanded]]
-    modId = "lithostitched"
-    type = "required"
-    ordering = "NONE"
-    side = "BOTH"

--- a/versions/1.21.1-neoforge/src/main/resources/theexpanse_1.21.1.mixins.json
+++ b/versions/1.21.1-neoforge/src/main/resources/theexpanse_1.21.1.mixins.json
@@ -11,6 +11,14 @@
     "LevelHeightAccessorMixin",
     "StrongholdStructureMixin",
     "OceanMonumentStructureMixin",
-    "MineshaftStructureMixin"
+    "MineshaftStructureMixin",
+    "litho.access.ChunkGeneratorAccessor",
+    "litho.access.HolderReferenceAccessor",
+    "litho.access.RandomStateAccessor",
+    "litho.server.DedicatedServerMixin",
+    "litho.server.GameTestServerMixin"
+  ],
+  "client": [
+    "litho.client.IntegratedServerMixin"
   ]
 }

--- a/versions/1.21.5-neoforge/gradle.properties
+++ b/versions/1.21.5-neoforge/gradle.properties
@@ -3,6 +3,5 @@ modstitch.platform=moddevgradle
 deps.minecraft=1.21.5
 deps.neoforge=21.5.39-beta
 deps.neoform=1.21.5-20250325.162830
-deps.lithostitched=1.4.6-neoforge-1.21.5
 deps.terralith=vGKEdR1w
 deps.clifftree=2.1.1+mod

--- a/versions/1.21.5-neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/versions/1.21.5-neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -23,8 +23,3 @@ license = "MIT"
     type = "required"
     versionRange = "[1.21.5,1.21.6)"
 
-[[dependencies.tectonicexpanded]]
-    modId = "lithostitched"
-    type = "required"
-    ordering = "NONE"
-    side = "BOTH"


### PR DESCRIPTION
## Summary
- vendor the Lithostitched modifier, placement, and density function helpers under `com.cyberday1.theexpanse.litho`
- hook the NeoForge entrypoint and mixin configs into the new registries and modifier application path
- remove the external Lithostitched dependency and add a validation task guarding against stray imports

## Testing
- ./gradlew clean build --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbe0efe0f08327b17da87b73c7aa00