### PR TITLE
Pin MixinExtras dependency to JitPack commit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,7 +133,7 @@ repositories {
     mavenCentral()
     maven { url = uri("https://maven.neoforged.net/releases") }
     maven { url = uri("https://maven.parchmentmc.org") }
-    maven { url = uri("https://jitpack.io") } // Added for MixinExtras
+    maven { url = uri("https://jitpack.io") }
 }
 
 // All dependencies should be specified through modstitch's proxy configuration.
@@ -147,7 +147,7 @@ dependencies {
         }
         because("NeoForge bundles Sponge Mixin; force Java 21 compatible version")
     }
-    implementation("com.github.LlamaLad7:MixinExtras:0.4.1") {
+    implementation("com.github.LlamaLad7:MixinExtras:73e5b74") {
         because("Needed for @WrapOperation and other extensions")
     }
 
@@ -190,25 +190,17 @@ tasks.register("validateMixinCompatLevel") {
     }
 }
 
-val allowedMixinExtrasVersions = setOf(
-    "0.4.1",
-    "73e5b74a55e7de77b084c5a4230eac0c5937c547"
-)
-
 val validateMixinExtrasCoords = tasks.register("validateMixinExtrasCoords") {
     doLast {
+        val allowedVersions = setOf("73e5b74")
         val compileClasspath = configurations.getByName("compileClasspath")
         val badDeps = compileClasspath.resolvedConfiguration.resolvedArtifacts.filter {
             val moduleVersion = it.moduleVersion.id
-            val isMixinExtras = moduleVersion.name == "MixinExtras"
-            val isLegacyGroup = moduleVersion.group == "com.llamalad7" && isMixinExtras
-            val hasDisallowedVersion = moduleVersion.group == "com.github.LlamaLad7" &&
-                isMixinExtras && moduleVersion.version !in allowedMixinExtrasVersions
-
-            isLegacyGroup || hasDisallowedVersion
+            moduleVersion.group == "com.llamalad7" ||
+                (moduleVersion.group == "com.github.LlamaLad7" && moduleVersion.version !in allowedVersions)
         }
         if (badDeps.isNotEmpty()) {
-            throw GradleException("Invalid MixinExtras coordinates or version detected. Allowed: com.github.LlamaLad7:MixinExtras:0.4.1 or a pinned commit id.")
+            throw GradleException("Invalid MixinExtras coordinates detected. Allowed: com.github.LlamaLad7:MixinExtras:73e5b74 only.")
         }
     }
 }

--- a/versions/1.21.1-neoforge/build.gradle.kts
+++ b/versions/1.21.1-neoforge/build.gradle.kts
@@ -11,6 +11,10 @@ neoForge {
     neoFormVersion = "1.21.1-20240808.144430"
 }
 
+dependencies {
+    implementation("com.github.LlamaLad7:MixinExtras:73e5b74")
+}
+
 tasks.named<Jar>("jar") {
     archiveBaseName.set("TectonicExpanded")
     archiveVersion.set("${modVersion}+mc${mcVersion}-neoforge")

--- a/versions/1.21.5-neoforge/build.gradle.kts
+++ b/versions/1.21.5-neoforge/build.gradle.kts
@@ -11,6 +11,10 @@ neoForge {
     neoFormVersion = "1.21.5-20250325.162830"
 }
 
+dependencies {
+    implementation("com.github.LlamaLad7:MixinExtras:73e5b74")
+}
+
 tasks.named<Jar>("jar") {
     archiveBaseName.set("TectonicExpanded")
     archiveVersion.set("${modVersion}+mc${mcVersion}-neoforge")


### PR DESCRIPTION
## Summary
- ensure the shared buildscript always includes the JitPack repository
- pin every NeoForge module and the root project to com.github.LlamaLad7:MixinExtras:73e5b74
- tighten the mixin validation task so that only the pinned commit is accepted

## Testing
- ./gradlew clean build --refresh-dependencies --no-daemon --console=plain *(fails: JitPack does not publish artifacts for com.github.LlamaLad7:MixinExtras:73e5b74)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfb5892fc8327863db05b0245e59d